### PR TITLE
Add handling of byproducts

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -107,10 +107,6 @@ export function handleByproducts(factory: FactoryGraph) {
         }
         const recipe = findRecipe(container.item)
         for (const byproduct of recipe.byproducts) {
-            /* Skip ores (but there should be none anyway) */
-            if (isOre(byproduct.item)) {
-                continue
-            }
             /* Check if byproduct is already being consumed */
             let isConsumed = false
             for (const consumer of container.consumers) {
@@ -120,31 +116,17 @@ export function handleByproducts(factory: FactoryGraph) {
             }
             if (!isConsumed) {
                 /* Check if there is already a transfer unit for this item */
-                let industry: TransferNode | undefined
-                const itemTransfers = Array.from(factory.getTransfers(byproduct.item))
+                let transfer: TransferNode | undefined
+                const itemTransfers = factory.getTransferUnits(byproduct.item)
                 for (const itemTransfer of itemTransfers) {
                     if (itemTransfer.canAddIncomingLinks(1)) {
-                        console.log(
-                            "Adding " +
-                                byproduct.item.name +
-                                " from " +
-                                container.item.name +
-                                " to existing",
-                        )
-                        industry = itemTransfer
+                        transfer = itemTransfer
                     }
                 }
                 /* Create a new transfer unit if necessary */
-                if (industry === undefined) {
-                    industry = new TransferNode(byproduct.item)
-                    console.log(
-                        "Adding " +
-                            byproduct.item.name +
-                            " from " +
-                            container.item.name +
-                            " to new",
-                    )
-                    factory.addIndustry(industry)
+                if (transfer === undefined) {
+                    transfer = new TransferNode(byproduct.item)
+                    factory.addTransferUnit(transfer)
                     /* Find an output container that has space for an incoming link */
                     let output: ContainerNode | undefined
                     const itemContainers = factory.getContainers(byproduct.item)
@@ -158,9 +140,9 @@ export function handleByproducts(factory: FactoryGraph) {
                         output = new ContainerNode(byproduct.item)
                         factory.addContainer(output)
                     }
-                    industry.outputTo(output)
+                    transfer.outputTo(output)
                 }
-                industry.takeFrom(container, byproduct.item)
+                transfer.takeFrom(container, byproduct.item)
             }
         }
     }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -141,7 +141,7 @@ export class ContainerNode {
 
 export class ConsumerNode {
     /**
-     * Node that consumes product. Industry, Transfer Unit, or Output
+     * Node that consumes product. Industry or Output
      */
     readonly inputs: Map<Item, ContainerNode> = new Map()
 


### PR DESCRIPTION
Fixes https://github.com/lgfrbcsgo/du-factory-generator/issues/4 and https://github.com/lgfrbcsgo/du-factory-generator/issues/17

All byproducts are simply transferred to a container that contains that byproduct and has an incoming link slot available. This is fine for non-catalyst byproducts, but catalysts should really go back to their original container so that they can be reused. Otherwise, we may get a build up of catalysts in one container and an industry will need to keep producing catalysts to fill the original container.

This will be a bit tricky to implement. The catalyst consumers could be consuming from different catalyst containers and outputing to the same product container. In my factory, I ensure this does not happen. All industries that output to a single container draw their catalysts from the same container.

I will create an issue and work on this separately once this PR is merged.