### PR TITLE
Perpare for node labeling

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,7 +6,7 @@
 
 import { Craftable, isOre, Item } from "./items"
 import { findRecipe } from "./recipes"
-import { ContainerNode, FactoryGraph, IndustryNode, OutputNode, PerMinute } from "./graph"
+import { ContainerNode, FactoryGraph, PerMinute } from "./graph"
 
 /**
  * Add to the a factory graph all nodes required to produce and store a given item
@@ -32,8 +32,7 @@ export function buildDependencies(
         }
         if (output === undefined) {
             /* Create new ore container */
-            output = new ContainerNode(item)
-            factory.addContainer(output)
+            output = factory.createContainer(item)
         }
         return output
     }
@@ -61,8 +60,7 @@ export function buildDependencies(
     }
     /** Create a new container if necessary */
     if (output === undefined) {
-        output = new ContainerNode(item)
-        factory.addContainer(output)
+        output = factory.createContainer(item)
     }
     /** Add new producers */
     const count = Math.ceil(
@@ -70,9 +68,8 @@ export function buildDependencies(
             (recipe.product.quantity / recipe.time),
     )
     for (let i = 0; i < count; i++) {
-        const industry = new IndustryNode(item)
+        const industry = factory.createIndustry(item)
         industry.outputTo(output)
-        factory.addIndustry(industry)
         /** Build dependencies recursively */
         for (const ingredient of recipe.ingredients) {
             const input = buildDependencies(
@@ -102,9 +99,8 @@ export function buildFactory(
         const rate = (count * recipe.product.quantity) / recipe.time
         const container = buildDependencies(factory, item, rate)
         /* Create factory output node */
-        const output = new OutputNode(item, rate, maintain)
+        const output = factory.createOutput(item, rate, maintain)
         output.takeFrom(container, item)
-        factory.addOutput(output)
     }
     return factory
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -129,8 +129,7 @@ function handleByproducts(factory: FactoryGraph) {
                 }
                 /* Create a new transfer unit if necessary */
                 if (transfer === undefined) {
-                    transfer = new TransferNode(byproduct.item)
-                    factory.addTransferUnit(transfer)
+                    transfer = factory.createTransferUnit(byproduct.item)
                     /* Find an output container that has space for an incoming link */
                     let output: ContainerNode | undefined
                     const itemContainers = factory.getContainers(byproduct.item)
@@ -145,7 +144,7 @@ function handleByproducts(factory: FactoryGraph) {
                     }
                     transfer.outputTo(output)
                 }
-                transfer.takeFrom(container, byproduct.item)
+                transfer.takeFrom(container)
             }
         }
     }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -63,10 +63,9 @@ function findInputContainer(factory: FactoryGraph, item: Item, rate: PerMinute):
  * Add to the a factory graph all nodes required to satisfy the insufficient ingress of the given
  * container.
  * Recursively call this function to produce all ingredients.
- * @param factory FactoryGraph to be modified
  * @param output Container which has insufficient ingress
  */
-function satisfyContainerEgress(factory: FactoryGraph, output: ContainerNode): void {
+function satisfyContainerEgress(output: ContainerNode): void {
     if (isOre(output.item)) {
         return
     }
@@ -86,20 +85,20 @@ function satisfyContainerEgress(factory: FactoryGraph, output: ContainerNode): v
     }
 
     for (let i = 0; i < additionalIndustries; i++) {
-        const industry = factory.createIndustry(output.item)
+        const industry = output.factory.createIndustry(output.item)
         industry.outputTo(output)
 
         // Build dependencies recursively
         for (const ingredient of recipe.ingredients) {
             const input = findInputContainer(
-                factory,
+                output.factory,
                 ingredient.item,
                 ingredient.quantity / recipe.time,
             )
             industry.takeFrom(input)
 
             // Try to satisfy the updated egress of the container
-            satisfyContainerEgress(factory, input)
+            satisfyContainerEgress(input)
         }
     }
 }
@@ -119,7 +118,7 @@ export function buildFactory(
 
         // Create factory output node
         const container = factory.createOutput(item, rate, maintain)
-        satisfyContainerEgress(factory, container)
+        satisfyContainerEgress(container)
     }
     return factory
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -77,7 +77,7 @@ export function buildDependencies(
                 ingredient.item,
                 ingredient.quantity / recipe.time,
             )
-            industry.takeFrom(input, ingredient.item)
+            industry.takeFrom(input)
         }
     }
     return output
@@ -100,7 +100,7 @@ export function buildFactory(
         const container = buildDependencies(factory, item, rate)
         /* Create factory output node */
         const output = factory.createOutput(item, rate, maintain)
-        output.takeFrom(container, item)
+        output.takeFrom(container)
     }
     return factory
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -29,10 +29,7 @@ function findInputContainer(factory: FactoryGraph, item: Item, rate: PerMinute):
 
     // Search for containers which have excess ingress
     for (const container of containers) {
-        if (
-            container.getEgress() + rate <= container.getIngress() &&
-            container.outgoingLinkCount < 10
-        ) {
+        if (container.egress + rate <= container.ingress && container.outgoingLinkCount < 10) {
             return container
         }
     }
@@ -42,8 +39,8 @@ function findInputContainer(factory: FactoryGraph, item: Item, rate: PerMinute):
     // Search for containers which can accommodate extra producers
     const inputContainer = containers.find((container) => {
         const additionalMachines = Math.ceil(
-            (rate + (container.getEgress() - container.getIngress())) /
-            (recipe.product.quantity / recipe.time),
+            (rate + (container.egress - container.ingress)) /
+                (recipe.product.quantity / recipe.time),
         )
         return (
             container.incomingLinkCount + additionalMachines <= 10 &&
@@ -74,14 +71,12 @@ function satisfyContainerEgress(output: ContainerNode): void {
 
     // figure out the needed additional industries
     const additionalIndustries = Math.ceil(
-        (output.getEgress() - output.getIngress()) / (recipe.product.quantity / recipe.time),
+        (output.egress - output.ingress) / (recipe.product.quantity / recipe.time),
     )
 
     // sanity check that this container as enough incoming links left
     if (additionalIndustries + output.incomingLinkCount > 10) {
-        throw new Error(
-            `Egress of ${output.getEgress()} ${output.item} per minute cannot be satisfied.`,
-        )
+        throw new Error(`Egress of ${output.egress} ${output.item} per minute cannot be satisfied.`)
     }
 
     for (let i = 0; i < additionalIndustries; i++) {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -109,11 +109,13 @@ export function buildFactory(
     const factory = new FactoryGraph()
     for (const [item, { count, maintain }] of requirements) {
         const recipe = findRecipe(item)
-        const rate = (count * recipe.product.quantity) / recipe.time
+        const rate = recipe.product.quantity / recipe.time
 
-        // Create factory output node
-        const container = factory.createOutput(item, rate, maintain)
-        satisfyContainerEgress(container)
+        for (let i = 0; i < count; i++) {
+            // Create factory output node
+            const container = factory.createOutput(item, rate, maintain)
+            satisfyContainerEgress(container)
+        }
     }
     return factory
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -139,6 +139,9 @@ export class IndustryNode {
      * @param container Input container
      */
     takeFrom(container: ContainerNode) {
+        if (this.inputs.has(container.item)) {
+            this.inputs.get(container.item)!.consumers.delete(this)
+        }
         this.inputs.set(container.item, container)
         container.consumers.add(this)
     }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -46,7 +46,7 @@ export class ContainerNode {
     /**
      * Return the rate at which the producers are filling this container.
      */
-    getIngress(): PerMinute {
+    get ingress(): PerMinute {
         return Array.from(this.producers)
             .map((producer) => producer.getOutput(this.item))
             .reduce((totalIngress, ingress) => totalIngress + ingress, 0)
@@ -55,7 +55,7 @@ export class ContainerNode {
     /**
      * Return the rate at which the consumers are drawing from this container.
      */
-    getEgress(): PerMinute {
+    get egress(): PerMinute {
         return Array.from(this.consumers)
             .map((producer) => producer.getInput(this.item))
             .reduce((totalEgress, egress) => totalEgress + egress, 0)
@@ -114,8 +114,8 @@ export class OutputNode extends ContainerNode {
         super(item, factory)
     }
 
-    getEgress(): PerMinute {
-        return super.getEgress() + this.outputRate
+    get egress(): PerMinute {
+        return super.egress + this.outputRate
     }
 
     get maintain(): Quantity {
@@ -194,6 +194,13 @@ export class FactoryGraph {
     industries = new Set<IndustryNode>()
 
     /**
+     * Return the set of all products produced or stored in this factory
+     */
+    get products(): Set<Item> {
+        return new Set(Array.from(this.containers).map((node) => node.item))
+    }
+
+    /**
      * Add an industry to the factory graph
      * @see {@link IndustryNode}
      */
@@ -241,12 +248,5 @@ export class FactoryGraph {
      */
     getContainers(item: Item): Set<ContainerNode> {
         return new Set(Array.from(this.containers).filter((node) => node.item === item))
-    }
-
-    /**
-     * Return the set of all products produced or stored in this factory
-     */
-    getProducts(): Set<Item> {
-        return new Set(Array.from(this.containers).map((node) => node.item))
     }
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -25,8 +25,9 @@ export class ContainerNode {
     /**
      * Initialize a new ContainerNode
      * @param item Item stored in this container
+     * @param factory The factory this container belongs to
      */
-    constructor(readonly item: Item) {}
+    constructor(readonly item: Item, readonly factory: FactoryGraph) {}
 
     /**
      * Return the number of producers filling this container
@@ -97,15 +98,20 @@ export class ContainerNode {
  * Factory output node
  */
 export class OutputNode extends ContainerNode {
-
     /**
      * Initialize a new OutputNode
      * @param item Item produced by this industry
      * @param outputRate Required production rate
      * @param maintainedOutput The number of items to maintain
+     * @param factory The factory this output belongs to
      */
-    constructor(readonly item: Craftable, readonly outputRate: PerMinute, readonly maintainedOutput: Quantity) {
-        super(item)
+    constructor(
+        item: Craftable,
+        readonly outputRate: PerMinute,
+        readonly maintainedOutput: Quantity,
+        factory: FactoryGraph,
+    ) {
+        super(item, factory)
     }
 
     getEgress(): PerMinute {
@@ -126,7 +132,7 @@ export class IndustryNode {
 
     output: ContainerNode | undefined
 
-    constructor(readonly item: Craftable) {}
+    constructor(readonly item: Craftable, readonly factory: FactoryGraph) {}
 
     /**
      * Add or replace input container for an item
@@ -192,7 +198,7 @@ export class FactoryGraph {
      * @see {@link IndustryNode}
      */
     createIndustry(item: Craftable): IndustryNode {
-        const industry = new IndustryNode(item)
+        const industry = new IndustryNode(item, this)
         this.industries.add(industry)
         return industry
     }
@@ -202,7 +208,7 @@ export class FactoryGraph {
      * @see {@link ContainerNode}
      */
     createContainer(item: Item): ContainerNode {
-        const container = new ContainerNode(item)
+        const container = new ContainerNode(item, this)
         this.containers.add(container)
         return container
     }
@@ -212,7 +218,7 @@ export class FactoryGraph {
      * @see {@link OutputNode}
      */
     createOutput(item: Craftable, outputRate: PerMinute, maintainedOutput: Quantity): OutputNode {
-        const output = new OutputNode(item, outputRate, maintainedOutput)
+        const output = new OutputNode(item, outputRate, maintainedOutput, this)
         this.containers.add(output)
         return output
     }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -4,11 +4,11 @@
  * lgfrbcsgo & Nikolaus - October 2020
  */
 import {
+    ContainerElement,
+    CONTAINERS_ASCENDING_BY_CAPACITY,
     Craftable,
     Item,
     Quantity,
-    ContainerElement,
-    CONTAINERS_ASCENDING_BY_CAPACITY,
 } from "./items"
 import { findRecipe } from "./recipes"
 
@@ -144,6 +144,7 @@ export class OutputNode extends ConsumerNode {
      * Initialize a new OutputNode
      * @param item Item produced by this industry
      * @param rate Required production rate
+     * @param maintain The number of items to maintain
      */
     constructor(readonly item: Craftable, readonly rate: PerMinute, readonly maintain: Quantity) {
         super(item)
@@ -214,26 +215,32 @@ export class FactoryGraph {
 
     /**
      * Add an industry to the factory graph
-     * @param industry Industry to add
+     * See {@link IndustryNode}
      */
-    addIndustry(industry: IndustryNode) {
+    createIndustry(item: Craftable): IndustryNode {
+        const industry = new IndustryNode(item)
         this.industries.add(industry)
+        return industry
     }
 
     /**
      * Add a container to the factory graph
-     * @param container Container to add
+     * See {@link ContainerNode}
      */
-    addContainer(container: ContainerNode) {
+    createContainer(item: Item): ContainerNode {
+        const container = new ContainerNode(item)
         this.containers.add(container)
+        return container
     }
 
     /**
      * Add an output node to the factory graph
-     * @param node ConsumerNode to add
+     * See {@link OutputNode}
      */
-    addOutput(node: OutputNode) {
-        this.outputs.add(node)
+    createOutput(item: Craftable, rate: PerMinute, maintain: Quantity): OutputNode {
+        const output = new OutputNode(item, rate, maintain)
+        this.outputs.add(output)
+        return output
     }
 
     /**


### PR DESCRIPTION
Some refactoring to make adding labels to node easier.

Refactors `OutputNode`s into a special case of a `ContainerNode`. This also fixes `OutputNode`s consuming links.

The algorithm has been slightly modified. Instead of returning a container for a given rate, it is given a container whose egress it needs to satisfy. Therefore, it has been split into two functions:
- `findInputContainer` which finds or creates a new input container for an industry
- `satisfyContainerEgress` which tries to satisfy the egress of a container by adding more industries to it

Other changes to make `time to action` easier:
- Whenever a industry needs ore, a new container is created
- Each final assembly industry is assigned its own output container
