### PR TITLE
CSV Selection, Bug Fix, and OutputNode Change

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -4,7 +4,7 @@
  * lgfrbcsgo & Nikolaus - October 2020
  */
 
-import { Craftable, isOre, Item, CATALYSTS, isCatalyst } from "./items"
+import { Craftable, isOre, Item, CATALYSTS, isCatalyst, containerElement } from "./items"
 import { findRecipe } from "./recipes"
 import {
     ContainerNode,
@@ -519,6 +519,26 @@ export function buildFactory(
                 output.maintainedOutput += maintain
             }
         }
+
+        if (output === undefined) {
+            // check if there is a container node that we could use
+            const containers = factory.getContainers(item)
+            for (const container of containers) {
+                if (container.canAddIncomingLinks(count)) {
+                    // convert container to output node
+                    output = factory.createOutput(item, rate * count, maintain, container.id)
+                    for (const producer of container.producers) {
+                        producer.outputTo(output)
+                    }
+                    for (const consumer of container.consumers) {
+                        consumer.inputs.delete(container)
+                        consumer.takeFrom(output)
+                    }
+                    factory.containers.delete(container)
+                }
+            }
+        }
+
         if (output === undefined) {
             // add a new output node
             output = factory.createOutput(item, rate * count, maintain)

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -4,7 +4,7 @@
  * lgfrbcsgo & Nikolaus - October 2020
  */
 
-import { Craftable, isOre, Item, CATALYSTS, isCatalyst, containerElement } from "./items"
+import { Craftable, isOre, Item, CATALYSTS, isCatalyst } from "./items"
 import { findRecipe } from "./recipes"
 import {
     ContainerNode,

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -771,8 +771,8 @@ export class FactoryGraph {
             node.items.some((item) => Array.from(items).includes(item)),
         )
         // Filter out those containing anything not in items
-        transferContainers = transferContainers.filter((node) =>
-            Array.from(items).some((item) => !node.items.includes(item)),
+        transferContainers = transferContainers.filter(
+            (node) => !node.items.some((item) => !Array.from(items).includes(item)),
         )
         return new Set(transferContainers)
     }

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -66,5 +66,5 @@ export function useMap<Key, Value>() {
         newCounter.set(key, value)
         setMap(newCounter)
     }
-    return [map, setValue] as const
+    return [map, setValue, setMap] as const
 }

--- a/src/ui/factory-instruction.tsx
+++ b/src/ui/factory-instruction.tsx
@@ -246,23 +246,30 @@ export class FactoryInstruction {
         const container_y = start_y + (producer_y - start_y) / 2
         let ingress = 0
         let egress = 0
+        let outputRate = 0
         let unit = "sec"
         if (isContainerNode(this.container)) {
             ingress = this.container.ingress * 60.0
             egress = this.container.egress * 60.0
+            if (isOutputNode(this.container)) {
+                outputRate = this.container.outputRate * 60.0
+            }
             unit = "min"
             if (egress < 1) {
                 ingress *= 60.0
                 egress *= 60.0
+                outputRate *= 60.0
                 unit = "hour"
             }
             if (egress < 1) {
                 ingress *= 24.0
                 egress *= 24.0
+                outputRate *= 24.0
                 unit = "day"
             }
             ingress = Math.round(ingress * 100) / 100
             egress = Math.round(egress * 100) / 100
+            outputRate = Math.round(outputRate * 100) / 100
         }
         element = (
             <React.Fragment key={this.container.name}>
@@ -363,6 +370,18 @@ export class FactoryInstruction {
                         >
                             {isContainerNode(this.container) && egress + "/" + unit}
                         </text>
+                        {isOutputNode(this.container) && (
+                            <text
+                                x={x + 1.5 * SIZE}
+                                y={container_y + SIZE / 2 - 5 + 20}
+                                fill="blue"
+                                fontSize={FONTSIZE}
+                                dominantBaseline="auto"
+                                textAnchor="middle"
+                            >
+                                ({outputRate + "/" + unit})
+                            </text>
+                        )}
                     </React.Fragment>
                 )}
             </React.Fragment>

--- a/src/ui/factory-instruction.tsx
+++ b/src/ui/factory-instruction.tsx
@@ -316,7 +316,7 @@ export class FactoryInstruction {
                     dominantBaseline="hanging"
                     textAnchor="middle"
                 >
-                    {isContainerNode(this.container) && this.container.maintain}
+                    {isContainerNode(this.container) && Math.ceil(this.container.maintain)}
                 </text>
                 {isOutputNode(this.container) && (
                     <text

--- a/src/ui/factory-instruction.tsx
+++ b/src/ui/factory-instruction.tsx
@@ -318,6 +318,18 @@ export class FactoryInstruction {
                 >
                     {isContainerNode(this.container) && this.container.maintain}
                 </text>
+                {isOutputNode(this.container) && (
+                    <text
+                        x={x + SIZE / 2}
+                        y={container_y + SIZE + 15}
+                        fill="blue"
+                        fontSize={FONTSIZE}
+                        dominantBaseline="hanging"
+                        textAnchor="middle"
+                    >
+                        ({this.container.maintainedOutput})
+                    </text>
+                )}
                 <text
                     x={x + SIZE / 2}
                     y={container_y + SIZE / 2}

--- a/src/ui/factory-map.tsx
+++ b/src/ui/factory-map.tsx
@@ -12,6 +12,8 @@ import { isContainerNode, isTransferContainerNode } from "../graph"
 import { FactoryInstruction } from "./factory-instruction"
 import { FONTSIZE, FactoryVisualizationComponentProps } from "./render-factory"
 
+const MAX_IMAGE_SIZE = 12500
+
 /**
  * Component for visualizing factory graph as a large map
  * @param props {@link FactoryVisualizationComponentProps}
@@ -24,8 +26,19 @@ export function FactoryMap({ instructions }: FactoryVisualizationComponentProps)
 
     function prepareDownload() {
         const canvas = document.createElement("canvas")
-        canvas.width = width
-        canvas.height = height
+        let scale = 1.0
+        let scaleWidth = width
+        let scaleHeight = height
+        if (scaleWidth > MAX_IMAGE_SIZE) {
+            scaleHeight *= MAX_IMAGE_SIZE / scaleWidth
+            scaleWidth *= MAX_IMAGE_SIZE / scaleWidth
+        }
+        if (scaleHeight > MAX_IMAGE_SIZE) {
+            scaleWidth *= MAX_IMAGE_SIZE / scaleHeight
+            scaleHeight *= MAX_IMAGE_SIZE / scaleHeight
+        }
+        canvas.width = scaleWidth
+        canvas.height = scaleHeight
         const ctx = canvas.getContext("2d")!
         const svg = (
             <svg
@@ -44,7 +57,7 @@ export function FactoryMap({ instructions }: FactoryVisualizationComponentProps)
         const svgURL = DOMURL.createObjectURL(svgBlob)
         const img = new Image()
         img.onload = () => {
-            ctx.drawImage(img, 0, 0)
+            ctx.drawImage(img, 0, 0, scaleWidth, scaleHeight)
             DOMURL.revokeObjectURL(svgURL)
             triggerDownload(canvas)
         }

--- a/src/ui/factory-select.tsx
+++ b/src/ui/factory-select.tsx
@@ -6,7 +6,6 @@
 
 import * as React from "react"
 import { Button, Upload } from "antd"
-import { compose } from "ramda"
 import { ItemSelect } from "./item-select"
 import { Craftable } from "../items"
 import { FactoryState } from "./factory"

--- a/src/ui/factory-select.tsx
+++ b/src/ui/factory-select.tsx
@@ -5,7 +5,8 @@
  */
 
 import * as React from "react"
-import { Button } from "antd"
+import { Button, Upload } from "antd"
+import { compose } from "ramda"
 import { ItemSelect } from "./item-select"
 import { Craftable } from "../items"
 import { FactoryState } from "./factory"
@@ -31,25 +32,75 @@ interface FactorySelectProps {
      * @param selection items to craft
      */
     setSelection: (selection: Craftable[]) => void
+
+    /**
+     * Set the number of assemblers map
+     * @param item Item to set the number of assemblers
+     */
+    setIndustryCountMap: (map: Map<Craftable, number>) => void
+
+    /**
+     * Set the maintain value map
+     * @param item Item to set the maintain value
+     */
+    setMaintainValueMap: (map: Map<Craftable, number>) => void
 }
 
 /**
  * Factory select elements to build component
  * @param props {@link FactorySelectProps}
  */
-export function FactorySelect({
-    setFactoryState,
-    items,
-    selection,
-    setSelection,
-}: FactorySelectProps) {
+export function FactorySelect(props: FactorySelectProps) {
     return (
         <React.Fragment>
             <h2>Select elements to build:</h2>
-            <ItemSelect items={items} value={selection} onChange={setSelection} />
-            <Button type="primary" onClick={() => setFactoryState(FactoryState.COUNT)}>
+            <ItemSelect items={props.items} value={props.selection} onChange={props.setSelection} />
+            <Button type="primary" onClick={() => props.setFactoryState(FactoryState.COUNT)}>
                 Next
             </Button>
+            <Upload
+                accept=".csv"
+                showUploadList={false}
+                beforeUpload={(file) => {
+                    const reader = new FileReader()
+                    reader.onload = () => {
+                        const result = reader.result as string
+                        const lines = result.split("\n")
+                        const myItems: Craftable[] = []
+                        const assemblerMap: Map<Craftable, number> = new Map()
+                        const maintainMap: Map<Craftable, number> = new Map()
+                        for (const line of lines) {
+                            const parts = line.split(",")
+                            if (
+                                parts[0].trim() === "" ||
+                                parts[1].trim() === "" ||
+                                parts[2].trim() === ""
+                            ) {
+                                continue
+                            }
+                            const item = props.items.find(
+                                (element) => element.name === parts[0].trim(),
+                            )
+                            if (item === undefined) {
+                                console.log("Item " + parts[0].trim() + "not found")
+                                continue
+                            }
+                            myItems.push(item)
+                            assemblerMap.set(item, Number(parts[1].trim()))
+                            maintainMap.set(item, Number(parts[2].trim()))
+                        }
+                        props.setSelection(myItems)
+                        props.setIndustryCountMap(assemblerMap)
+                        props.setMaintainValueMap(maintainMap)
+                        props.setFactoryState(FactoryState.COUNT)
+                    }
+                    reader.readAsText(file)
+                    // skip upload
+                    return false
+                }}
+            >
+                <Button>Upload CSV</Button>
+            </Upload>
         </React.Fragment>
     )
 }

--- a/src/ui/factory.tsx
+++ b/src/ui/factory.tsx
@@ -50,8 +50,8 @@ export function Factory({ setAppState, startFactoryState }: FactoryProps) {
     const [factoryInstructions, setFactoryInstructions] = React.useState<FactoryInstruction[]>([])
     // produced items, industry count, and maintain count
     const [selection, setSelection] = React.useState<Craftable[]>([])
-    const [industryCount, setIndustryCount] = useMap<Craftable, number>()
-    const [maintainValue, setMaintainValue] = useMap<Craftable, number>()
+    const [industryCount, setIndustryCount, setIndustryCountMap] = useMap<Craftable, number>()
+    const [maintainValue, setMaintainValue, setMaintainValueMap] = useMap<Craftable, number>()
     // the FactoryGraph and a flag to show differences
     const [showDifferences, setShowDifferences] = React.useState<boolean>(false)
     const [startingFactory, setStartingFactory] = React.useState<FactoryGraph>()
@@ -78,6 +78,8 @@ export function Factory({ setAppState, startFactoryState }: FactoryProps) {
                         items={items}
                         selection={selection}
                         setSelection={setSelection}
+                        setIndustryCountMap={setIndustryCountMap}
+                        setMaintainValueMap={setMaintainValueMap}
                     />
                 </React.Fragment>
             )

--- a/src/ui/item-select.tsx
+++ b/src/ui/item-select.tsx
@@ -79,7 +79,7 @@ function useItemTreeData<T extends Item>(items: T[]) {
  * @param items All selectable items
  * @param selection The currently selected items
  */
-function useItemSelection<T extends Item>(items: T[], selection: T[]) {
+export function useItemSelection<T extends Item>(items: T[], selection: T[]) {
     const byName = useMemo(() => indexBy(prop("name"), items), [items])
 
     const value = useMemo(() => selection.map(prop("name")), [selection])

--- a/src/ui/item-select.tsx
+++ b/src/ui/item-select.tsx
@@ -79,7 +79,7 @@ function useItemTreeData<T extends Item>(items: T[]) {
  * @param items All selectable items
  * @param selection The currently selected items
  */
-export function useItemSelection<T extends Item>(items: T[], selection: T[]) {
+function useItemSelection<T extends Item>(items: T[], selection: T[]) {
     const byName = useMemo(() => indexBy(prop("name"), items), [items])
 
     const value = useMemo(() => selection.map(prop("name")), [selection])


### PR DESCRIPTION
1. Adds the ability to upload a CSV file (formatted like: item name, number of assemblers, maintain value) to make item selection
2. Fixes a bug with transfer containers (logic of `getTransferContainers` was wrong, returning containers that contained items *not* in the requested set)
3. Check if any existing container can be transformed into an OutputNode before creating a new OutputNode.
4. Show the requested OutputNode maintain value in the render (blue text below total maintain value)