### PR TITLE
Multiple transfer units to satisfy rates

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -59,14 +59,18 @@ export class Container {
      * Count the number of producers
      */
     get incomingLinkCount(): number {
-        return this.producers.size
+        return Array.from(this.producers)
+            .map((producer) => (isTransferUnit(producer) ? producer.number : 1))
+            .reduce((total, current) => total + current, 0)
     }
 
     /**
      * Count the number of consumers
      */
     get outgoingLinkCount(): number {
-        return this.consumers.size
+        return Array.from(this.consumers)
+            .map((consumer) => (isTransferUnit(consumer) ? consumer.number : 1))
+            .reduce((total, current) => total + current, 0)
     }
 
     /**

--- a/src/transfer-unit.ts
+++ b/src/transfer-unit.ts
@@ -123,10 +123,7 @@ export class TransferUnit {
             return 0
         }
 
-        // maximum transfer rate
-        const maxRate = this.item.transferBatchSize / this.item.transferTime
-
-        return Math.min(maxRate, this.transferRates.get(container)!)
+        return this.transferRates.get(container)!
     }
 
     /**
@@ -142,13 +139,22 @@ export class TransferUnit {
             return 0
         }
 
-        // maximum transfer rate
-        const maxRate = this.item.transferBatchSize / this.item.transferTime
-
-        return Math.min(
-            maxRate,
-            Array.from(this.transferRates.values()).reduce((total, current) => total + current, 0),
+        return Array.from(this.transferRates.values()).reduce(
+            (total, current) => total + current,
+            0,
         )
+    }
+
+    /**
+     * The number of transfer units required to satisfy transfer rate
+     */
+    get number(): number {
+        const outflowRate = Array.from(this.transferRates.values()).reduce(
+            (total, current) => total + current,
+            0,
+        )
+        const maxTransferRate = this.item.transferBatchSize / this.item.transferTime
+        return Math.ceil(outflowRate / maxTransferRate)
     }
 }
 

--- a/src/ui/merge-node-instruction.tsx
+++ b/src/ui/merge-node-instruction.tsx
@@ -165,7 +165,7 @@ export class MergedNodeInstruction {
                         textAnchor="middle"
                     >
                         {isIndustry(producer) && INDUSTRYLABELS.get(producer.recipe.industry)}
-                        {isTransferUnit(producer) && producer.number + "xTrans"}
+                        {isTransferUnit(producer) && producer.number + "xTU"}
                     </text>
                     <text
                         x={x + SIZE / 2}

--- a/src/ui/merge-node-instruction.tsx
+++ b/src/ui/merge-node-instruction.tsx
@@ -165,7 +165,7 @@ export class MergedNodeInstruction {
                         textAnchor="middle"
                     >
                         {isIndustry(producer) && INDUSTRYLABELS.get(producer.recipe.industry)}
-                        {isTransferUnit(producer) && "Trans"}
+                        {isTransferUnit(producer) && producer.number + "xTrans"}
                     </text>
                     <text
                         x={x + SIZE / 2}

--- a/src/ui/node-instruction.tsx
+++ b/src/ui/node-instruction.tsx
@@ -215,7 +215,7 @@ export class NodeInstruction {
                             textAnchor="middle"
                         >
                             {isIndustry(producer) && INDUSTRYLABELS.get(producer.recipe.industry)}
-                            {isTransferUnit(producer) && "Trans"}
+                            {isTransferUnit(producer) && producer.number + "xTrans"}
                         </text>
                         <text
                             x={x + SIZE / 2}
@@ -501,7 +501,7 @@ export class NodeInstruction {
                         dominantBaseline="middle"
                         textAnchor="middle"
                     >
-                        Trans
+                        {relayRoute.transferUnit.number + "xTrans"}
                     </text>
                     <text
                         x={x + SIZE / 2}

--- a/src/ui/node-instruction.tsx
+++ b/src/ui/node-instruction.tsx
@@ -215,7 +215,7 @@ export class NodeInstruction {
                             textAnchor="middle"
                         >
                             {isIndustry(producer) && INDUSTRYLABELS.get(producer.recipe.industry)}
-                            {isTransferUnit(producer) && producer.number + "xTrans"}
+                            {isTransferUnit(producer) && producer.number + "xTU"}
                         </text>
                         <text
                             x={x + SIZE / 2}
@@ -501,7 +501,7 @@ export class NodeInstruction {
                         dominantBaseline="middle"
                         textAnchor="middle"
                     >
-                        {relayRoute.transferUnit.number + "xTrans"}
+                        {relayRoute.transferUnit.number + "xTU"}
                     </text>
                     <text
                         x={x + SIZE / 2}

--- a/src/ui/render-factory.tsx
+++ b/src/ui/render-factory.tsx
@@ -163,8 +163,10 @@ export function FactoryVisualization({
                 })
                 industryCount.set(
                     ITEMS["Transfer Unit"],
-                    Array.from(factory.transferUnits).filter((transferUnit) => !transferUnit.merged)
-                        .length,
+                    Array.from(factory.transferUnits)
+                        .filter((transferUnit) => !transferUnit.merged)
+                        .map((transferUnit) => transferUnit.number)
+                        .reduce((total, current) => total + current, 0),
                 )
                 totalIndustries += Array.from(factory.transferUnits).filter(
                     (transferUnit) => !transferUnit.merged,

--- a/src/ui/transfer-container-instruction.tsx
+++ b/src/ui/transfer-container-instruction.tsx
@@ -150,7 +150,7 @@ export class TransferContainerInstruction {
                         dominantBaseline="middle"
                         textAnchor="middle"
                     >
-                        {producer.number + "xTrans"}
+                        {producer.number + "xTU"}
                     </text>
                     <text
                         x={x + SIZE / 2}

--- a/src/ui/transfer-container-instruction.tsx
+++ b/src/ui/transfer-container-instruction.tsx
@@ -150,7 +150,7 @@ export class TransferContainerInstruction {
                         dominantBaseline="middle"
                         textAnchor="middle"
                     >
-                        Trans
+                        {producer.number + "xTrans"}
                     </text>
                     <text
                         x={x + SIZE / 2}


### PR DESCRIPTION
Due to finite transfer rates, a single transfer unit might not be enough to handle the dump -> relay transfer. This allows for multiple transfer units.